### PR TITLE
Adding pint unit checks and type hints to the Boiler

### DIFF
--- a/energy_box_control/appliances/base.py
+++ b/energy_box_control/appliances/base.py
@@ -2,6 +2,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
 import uuid
+from pint import UnitRegistry
+from energy_box_control.appliances.units import *
+
+ureg = UnitRegistry()
 
 
 @dataclass(frozen=True, eq=True)

--- a/energy_box_control/appliances/units.py
+++ b/energy_box_control/appliances/units.py
@@ -1,0 +1,5 @@
+Watt = float
+JoulesPerLiterKelvin = float
+Liter = float
+LiterPerSecond = float
+Kelvin = float

--- a/energy_box_control/networks.py
+++ b/energy_box_control/networks.py
@@ -20,11 +20,13 @@ from energy_box_control.appliances import (
     ValvePort,
     ValveState,
 )
+from energy_box_control.appliances.base import ureg
+from pint import Quantity
 
 
 @dataclass
 class BoilerSensors:
-    boiler_temperature: float
+    boiler_temperature: float | Quantity
 
 
 @dataclass
@@ -69,7 +71,9 @@ class BoilerNetwork(Network[BoilerSensors]):
     def regulate(
         self, control_state: ControlState, sensors: BoilerSensors
     ) -> tuple[(ControlState, NetworkControl[Self])]:
-        heater_on = sensors.boiler_temperature < control_state.boiler_setpoint
+        heater_on = (
+            sensors.boiler_temperature < control_state.boiler_setpoint * ureg.kelvin
+        )
 
         return (
             control_state,

--- a/energy_box_control/power_hub.py
+++ b/energy_box_control/power_hub.py
@@ -44,6 +44,7 @@ from energy_box_control.network import (
     NetworkControl,
 )
 from energy_box_control.networks import ControlState
+from energy_box_control.appliances.base import ureg
 
 
 WATER_SPECIFIC_HEAT = 4186 * 0.997  # J / l K
@@ -102,7 +103,13 @@ class PowerHub(Network[PowerHubSensors]):
             heat_pipes_valve=Valve(),
             heat_pipes_mix=Mix(),
             heat_pipes_pump=SwitchPump(15 / 60),
-            hot_reservoir=Boiler(130, 6, 40, GLYCOL_SPECIFIC_HEAT, WATER_SPECIFIC_HEAT),
+            hot_reservoir=Boiler(
+                130 * ureg.liter,
+                6 * ureg.watt,
+                40 * ureg.watt,
+                GLYCOL_SPECIFIC_HEAT * (ureg.joule / (ureg.liter * ureg.kelvin)),
+                WATER_SPECIFIC_HEAT * (ureg.joule / (ureg.liter * ureg.kelvin)),
+            ),
             hot_reservoir_pcm_valve=Valve(),
             hot_mix=Mix(),
             pcm=Pcm(
@@ -127,14 +134,24 @@ class PowerHub(Network[PowerHubSensors]):
                 WATER_SPECIFIC_HEAT,  # 2.5-18.7 kW cooling capacity
             ),
             chill_mix=Mix(),
-            cold_reservoir=Boiler(800, 0, 0, 0, WATER_SPECIFIC_HEAT),
+            cold_reservoir=Boiler(
+                800 * ureg.liter,
+                0 * ureg.watt,
+                0 * ureg.watt,
+                0 * (ureg.joule / (ureg.liter * ureg.kelvin)),
+                WATER_SPECIFIC_HEAT * (ureg.joule / (ureg.liter * ureg.kelvin)),
+            ),
             chilled_loop_pump=SwitchPump(70 / 60),  # 42 - 100 l/min
             yazaki_waste_bypass_valve=Valve(),
             yazaki_waste_mix=Mix(),
             waste_mix=Mix(),
             preheat_bypass_valve=Valve(),
             preheat_reservoir=Boiler(
-                100, 0, 36, WATER_SPECIFIC_HEAT, WATER_SPECIFIC_HEAT
+                100 * ureg.liter,
+                0 * ureg.watt,
+                36 * ureg.watt,
+                WATER_SPECIFIC_HEAT * (ureg.joule / (ureg.liter * ureg.kelvin)),
+                WATER_SPECIFIC_HEAT * (ureg.joule / (ureg.liter * ureg.kelvin)),
             ),
             preheat_mix=Mix(),
             outboard_exchange=HeatExchanger(
@@ -150,7 +167,7 @@ class PowerHub(Network[PowerHubSensors]):
 
     @staticmethod
     def example_initial_state(power_hub: "PowerHub") -> NetworkState["PowerHub"]:
-        initial_boiler_state = BoilerState(20)
+        initial_boiler_state = BoilerState(20 * ureg.kelvin)
         initial_valve_state = ValveState(0.5)
         return (
             power_hub.define_state(power_hub.heat_pipes_valve)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,6 +1,6 @@
 from typing import Self
 from pytest import approx
-from energy_box_control.appliances.base import ConnectionState
+from energy_box_control.appliances.base import ConnectionState, ureg
 from energy_box_control.network import (
     Network,
     NetworkConnections,
@@ -20,13 +20,21 @@ from energy_box_control.appliances import (
     ValveState,
 )
 
+from pint.testing import assert_allclose
+
 
 def test_network():
     class MyNetwork(Network[None]):
         exchange_source = Source(0, 1)
         fill_source = Source(0, 1)
         valve = Valve()
-        boiler = Boiler(1, 0, 0, 1, 1)
+        boiler = Boiler(
+            1 * ureg.liter,
+            0 * ureg.watt,
+            0 * ureg.watt,
+            1 * (ureg.joule / (ureg.liter * ureg.kelvin)),
+            1 * (ureg.joule / (ureg.liter * ureg.kelvin)),
+        )
 
         def initial_state(self):
             return (
@@ -37,7 +45,7 @@ def test_network():
                 .define_state(self.valve)
                 .value(ValveState(0.5))
                 .define_state(self.boiler)
-                .value(BoilerState(50))
+                .value(BoilerState(50 * ureg.kelvin))
                 .build()
             )
 
@@ -64,17 +72,29 @@ def test_network():
     my = MyNetwork()
     control = my.control(my.boiler).value(BoilerControl(heater_on=False)).build()
     state = my.simulate(my.initial_state(), control)
-    assert state.appliance(my.boiler).get().temperature == approx(50)
+    assert_allclose(
+        state.appliance(my.boiler).get().temperature.to_base_units(), 50 * ureg.kelvin
+    )
 
 
 def test_circular_network():
     """Tests a circular network with just a boiler this in essence turns the flow through the heat exchanger into extra heat capacity"""
 
     class CircularNetwork(Network[None]):
-        boiler = Boiler(99, 100, 0, 1, 1)
+        boiler = Boiler(
+            99 * ureg.liter,
+            100 * ureg.watt,
+            0 * ureg.watt,
+            1 * (ureg.joule / (ureg.liter * ureg.kelvin)),
+            1 * (ureg.joule / (ureg.liter * ureg.kelvin)),
+        )
 
         def initial_state(self) -> NetworkState[Self]:
-            return self.define_state(self.boiler).value(BoilerState(100)).build()
+            return (
+                self.define_state(self.boiler)
+                .value(BoilerState(100 * ureg.kelvin))
+                .build()
+            )
 
         def connections(self) -> NetworkConnections[Self]:
             return NetworkConnections([])
@@ -98,7 +118,11 @@ def test_circular_network():
     assert (
         state.connection(circle.boiler, BoilerPort.HEAT_EXCHANGE_OUT).temperature == 101
     )
-    assert state.appliance(circle.boiler).get().temperature == 101
+
+    assert_allclose(
+        state.appliance(circle.boiler).get().temperature.to_base_units(),
+        101 * ureg.kelvin,
+    )
 
     for _ in range(999):
         state = circle.simulate(state, control)
@@ -107,4 +131,7 @@ def test_circular_network():
         state.connection(circle.boiler, BoilerPort.HEAT_EXCHANGE_OUT).temperature
         == 1100
     )
-    assert state.appliance(circle.boiler).get().temperature == 1100
+    assert_allclose(
+        state.appliance(circle.boiler).get().temperature.to_base_units(),
+        1100 * ureg.kelvin,
+    )

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -2,6 +2,8 @@ from pytest import approx
 
 from energy_box_control.appliances import Boiler, BoilerState, Source
 from energy_box_control.networks import BoilerNetwork, ControlState
+from energy_box_control.appliances.base import ureg
+from pint.testing import assert_allclose
 
 
 def run(network: BoilerNetwork, state, control_state, times):
@@ -17,19 +19,31 @@ def run(network: BoilerNetwork, state, control_state, times):
 
 
 def test_heater():
-    network = BoilerNetwork(Source(0, 0), Boiler(10, 1, 0, 0, 1), BoilerState(0))
+    network = BoilerNetwork(
+        Source(0, 0),
+        Boiler(
+            10 * ureg.liter,
+            1 * ureg.watt,
+            0 * ureg.watt,
+            0 * (ureg.joule / (ureg.liter * ureg.kelvin)),
+            1 * (ureg.joule / (ureg.liter * ureg.kelvin)),
+        ),
+        BoilerState(0 * ureg.kelvin),
+    )
     control_state = ControlState(50)
 
     state_1, new_control_state = run(
         network, network.initial_state(), control_state, 1000
     )
 
-    assert state_1.appliance(network.boiler).get().temperature == approx(
-        control_state.boiler_setpoint
+    assert_allclose(
+        state_1.appliance(network.boiler).get().temperature.to_base_units(),
+        control_state.boiler_setpoint * ureg.kelvin,
     )
 
     state_2, new_control_state = run(network, state_1, control_state, 1000)
-    assert (
-        state_1.appliance(network.boiler).get().temperature
-        == state_2.appliance(network.boiler).get().temperature
+
+    assert_allclose(
+        state_1.appliance(network.boiler).get().temperature.to_base_units(),
+        state_2.appliance(network.boiler).get().temperature.to_base_units(),
     )

--- a/typings/pint/__init__.pyi
+++ b/typings/pint/__init__.pyi
@@ -1,0 +1,2 @@
+from .quantity import *
+from .unit_registry import *

--- a/typings/pint/quantity.pyi
+++ b/typings/pint/quantity.pyi
@@ -1,0 +1,14 @@
+from energy_box_control.appliances.units import *
+
+class Quantity:
+    def __add__(self, other: Quantity | float | int) -> Quantity: ...
+    __rmul__ = __add__
+    __truediv__ = __add__
+    __sub__ = __add__
+    __radd__ = __add__
+    __mul__ = __add__
+    __gt__ = __add__
+    __lt__ = __add__
+
+    magnitude: float
+    def to_base_units(self) -> Quantity: ...

--- a/typings/pint/unit_registry.pyi
+++ b/typings/pint/unit_registry.pyi
@@ -1,0 +1,6 @@
+from typing import Callable
+from .quantity import *
+
+class UnitRegistry:
+    def __getattr__(self, i: str) -> Quantity: ...
+    def check[T](self, *args: * tuple[str, ...]) -> Callable[[T], T]: ...


### PR DESCRIPTION
This is an example of what it could look like if we add both type hints and pint units to the code.  The base units can be found here: https://github.com/hgrecco/pint/blob/master/pint/default_en.txt, perhaps we need to use different, more suiting, ones. 

Some things to still fix:

- Pyright doesn't like the types coming out of the equilibrium_temperature
- I wasn't sure how to adapt the equilibrium_temperature, as it takes a watt/second (joule) term and a joule/kelvin term. Divide the first term by kelvin? 
- Adapting the base ConnectionState requires a lot of other tests to be adapted. 

I wanted your feedback on the use of both the type hint and pint first before I spend too much time on the above. Is this something we want to pursue?