### PR TITLE
Fix chiller control

### DIFF
--- a/energy_box_control/power_hub/control.py
+++ b/energy_box_control/power_hub/control.py
@@ -413,7 +413,7 @@ chill_transitions: dict[
         ChillControlMode.CHILL_YAZAKI,
     ): ready_for_yazaki,
     (ChillControlMode.NO_CHILL, ChillControlMode.PREPARE_CHILL_CHILLER): should_chill
-    & ~pcm_charged,  # start chill whith chiller if PCM is not fully charged
+    & ~pcm_charged,  # start chill with chiller if PCM is not fully charged
     (
         ChillControlMode.PREPARE_CHILL_CHILLER,
         ChillControlMode.CHILL_CHILLER,


### PR DESCRIPTION
I think this was a mistake in the code. Note that the pcm can be in 3 disjunct states: pcm_charged, pcm_discharged and somewhere between 0 and 100% charged (not expicitely defined). The idea is that switching to the yazaki chill requires a full pcm, and switching back happens when it's empty (to prevent frequent switching) 