### PR TITLE
Fix/google cloud log error filter

### DIFF
--- a/infra/google_alerting.tf
+++ b/infra/google_alerting.tf
@@ -25,7 +25,7 @@ resource "google_monitoring_alert_policy" "cloud_logs_error" {
   conditions {
     display_name = "Error condition"
     condition_matched_log {
-      filter = "severity=ERROR\n-resource.labels.container_name=\"gke-metrics-agent\"\nNOT textPayload:[INFO]"
+      filter = "severity=ERROR\n-resource.labels.container_name=\"gke-metrics-agent\"\nNOT textPayload:[INFO]\nNOT textPayload:\"see golang.org/issue/25192\""
       label_extractors = {
         "Message" = "EXTRACT(textPayload)"
       }


### PR DESCRIPTION
Added a filter for the following error, as I don't think it's relevant for our applications but more a warning for internal kubernetes processes (I don't recall us using semicolons in our api's, but perhaps I'm mistaken):

```
Log match condition with labels {Message=2024/07/23 09:13:30 http: URL query contains semicolon, which is no longer a supported separator; parts of the query may be stripped when parsed; see golang.org/issue/25192} fired for Kubernetes Container with {cluster_name=power-hub-staging-gke, container_name=default-http-backend, location=europe-west1, namespace_name=kube-system, pod_name=l7-default-backend-6484dd554-z2b2p, project_id=power-hub-423312}.
```