### PR TITLE
Adapt health bound check to include the bounds as healthy

### DIFF
--- a/energy_box_control/monitoring/checks.py
+++ b/energy_box_control/monitoring/checks.py
@@ -156,7 +156,7 @@ def valid_value(
             name=name,
             sensor_fn=value_fn,
             check_fn=lambda value: (
-                health_bound.lower_bound < value < health_bound.upper_bound
+                health_bound.lower_bound <= value <= health_bound.upper_bound
                 if not isnan(value)
                 else True
             ),

--- a/energy_box_control/monitoring/health_bounds.py
+++ b/energy_box_control/monitoring/health_bounds.py
@@ -8,16 +8,16 @@ class HealthBound:
 
 
 CONTAINER_BOUNDS = {
-    "co2": HealthBound(20, 100),
-    "humidity": HealthBound(20, 100),
+    "co2": HealthBound(20, 99),
+    "humidity": HealthBound(20, 99),
     "temperature": HealthBound(15, 35),
 }
 
 TANK_BOUNDS = {
-    "grey_water_tank": HealthBound(0, 1),
+    "grey_water_tank": HealthBound(0, 0.99),
     "black_water_tank": HealthBound(0, 0.9),
-    "technical_water_tank": HealthBound(0.4, 1),
-    "fresh_water_tank": HealthBound(0.4, 1),
+    "technical_water_tank": HealthBound(0.4, 0.99),
+    "fresh_water_tank": HealthBound(0.4, 0.99),
 }
 
 

--- a/tests/monitoring/test_monitoring.py
+++ b/tests/monitoring/test_monitoring.py
@@ -57,23 +57,31 @@ def test_pcm_values_checks(sensors, source):
     )
 
 
+def test_equal_bounds(sensors, source):
+    sensors.hot_switch_valve.flow = 0
+    sensors.hot_switch_valve.position = HOT_RESERVOIR_PCM_VALVE_PCM_POSITION
+    monitor = Monitor(sensor_value_checks=all_checks)
+    source = "test"
+    assert len(monitor.run_sensor_value_checks(sensors, source)) == 0
+
+
 @pytest.mark.parametrize(
     "attr,check_name,valve_name,valve_attr,valve_position",
     [
-        # (
-        #     "charge_input_temperature",
-        #     "hot_circuit_temperature_check",
-        #     "hot_switch_valve",
-        #     "input_temperature",
-        #     HOT_RESERVOIR_PCM_VALVE_PCM_POSITION,
-        # ),
-        # (
-        #     "charge_flow",
-        #     "hot_circuit_flow_check",
-        #     "hot_switch_valve",
-        #     "flow",
-        #     HOT_RESERVOIR_PCM_VALVE_PCM_POSITION,
-        # ),
+        (
+            "charge_input_temperature",
+            "hot_circuit_temperature_check",
+            "hot_switch_valve",
+            "input_temperature",
+            HOT_RESERVOIR_PCM_VALVE_PCM_POSITION,
+        ),
+        (
+            "charge_flow",
+            "hot_circuit_flow_check",
+            "hot_switch_valve",
+            "flow",
+            HOT_RESERVOIR_PCM_VALVE_PCM_POSITION,
+        ),
         (
             "charge_pressure",
             "hot_circuit_pressure_check",
@@ -81,7 +89,7 @@ def test_pcm_values_checks(sensors, source):
             "pressure",
             HOT_RESERVOIR_PCM_VALVE_PCM_POSITION,
         ),
-        # ("temperature", "pcm_temperature_check", None, None, None),
+        ("temperature", "pcm_temperature_check", None, None, None),
     ],
 )
 def test_hot_circuit_checks(


### PR DESCRIPTION
I got some alerts in PagerDuty:

`hot_circuit_flow_check is outside valid bounds with value: 0`

As 0 is a valid flow, I adapted the health check to test for less/greater than **or equal**, I think that makes more sense. 