### PR TITLE
Rely on auto-upgrade for the node pool

### DIFF
--- a/infra/gke.tf
+++ b/infra/gke.tf
@@ -39,7 +39,6 @@ resource "google_container_node_pool" "primary_nodes" {
   location = var.region
   cluster  = google_container_cluster.primary.name
 
-  version = data.google_container_engine_versions.gke_version.release_channel_default_version["REGULAR"]
   node_count = var.gke_num_nodes
 
   node_config {


### PR DESCRIPTION
Auto upgrade will interfere with explicit versions. I'm expecting us to prefer passive over active maintenance, so I'm suggesting we leave auto upgrade enabled and just go with that version instead of the alternative: disabling auto upgrade and having terraform do the upgrades for us. Also because those take forever

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#version