### PR TITLE
Make chiller status check float tolerant

### DIFF
--- a/energy_box_control/power_hub/sensors.py
+++ b/energy_box_control/power_hub/sensors.py
@@ -904,7 +904,7 @@ class ChillerSensors(FromState):
         return [
             fault
             for index, faults in enumerate(CHILLER_FAULTS)
-            if self.fault_code & (1 << index)
+            if int(self.fault_code) & (1 << index)
             for fault in faults
         ]
 


### PR DESCRIPTION
While the PLC should send ints, it may not and we don't want to break things