### PR TITLE
Run outboard if the water maker triggers

### DIFF
--- a/energy_box_control/power_hub/control/state.py
+++ b/energy_box_control/power_hub/control/state.py
@@ -107,6 +107,9 @@ class Setpoints:
     heat_dump_outboard_divergence_temperature: Celsius = setpoint(
         "Trigger temperature difference for the outboard pump toggle"
     )
+    fresh_water_tank_water_maker_trigger: Ratio = setpoint(
+        "level of the fresh water tank at which the water maker triggers"
+    )
 
 
 @dataclass
@@ -155,6 +158,7 @@ def initial_control_state() -> PowerHubControlState:
             low_battery=0.55,
             high_heat_dump_temperature=38,
             heat_dump_outboard_divergence_temperature=3,
+            fresh_water_tank_water_maker_trigger=0.35,  # level of the fresh water tank at which the water maker triggers
         ),
         hot_control=HotControlState(
             context=Context(),

--- a/energy_box_control/power_hub/control/waste/state.py
+++ b/energy_box_control/power_hub/control/waste/state.py
@@ -8,6 +8,9 @@ class WasteControlMode(State):
     RUN_OUTBOARD = "run_outboard"
     TOGGLE_OUTBOARD = "toggle_outboard"  # used to toggle the signal to the pump, when the frequency controller starts (after a power outage) it turns on at a rising edge
     RUN_OUTBOARD_AFTER_TOGGLE = "run_outboard_after_toggle"  # keep running the outboard after toggle to return to normal state
+    RUN_OUTBOARD_FOR_WATER_MAKER = (
+        "run_outboard_for_water_maker"  # run the outboard pump for the water maker
+    )
 
 
 @dataclass


### PR DESCRIPTION
Water maker status is delayed, so speculatively run the outboard pump for long enough for its status to change