### PR TITLE
Pass mqtt websockets for power hub dashboard through nginx

### DIFF
--- a/apps/dashboard/.env.powerhub
+++ b/apps/dashboard/.env.powerhub
@@ -1,4 +1,4 @@
-VITE_MQTT=ws://mosquitto:9001
+VITE_MQTT=ws://%HOST%/ws
 VITE_API=https://api.prod.power-hub.foundationzero.org
 VITE_API_BEARER_TOKEN=
 VITE_MQTT_USER=readonly

--- a/apps/dashboard/nginx/default.conf
+++ b/apps/dashboard/nginx/default.conf
@@ -3,7 +3,17 @@ server {
   server_name localhost;
   root /usr/share/nginx/html;
   index index.html index.htm;
+
+  location /ws {
+    proxy_pass http://mosquitto:9001/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+  }
+
   location / {
     try_files $uri $uri/ /index.html;
   }
+
 }

--- a/apps/docker-compose.yaml
+++ b/apps/docker-compose.yaml
@@ -6,3 +6,10 @@ services:
     container_name: powerhub-dashboard
     ports:
       - 8180:80
+
+  mosquitto:
+    image: eclipse-mosquitto:2.0.14
+    restart: always
+    volumes:
+      - ../plc/mosquitto:/mosquitto/config
+      - ./certs/ISRG_ROOT_X1.crt:/mosquitto/certs/ca.crt


### PR DESCRIPTION
Previously used docker service name, which isn't available on clients except when they edit the /etc/hosts, which isn't desirable

Test using:
* `cd apps`
* `docker compose build dashboard`
* `docker compose up mosquitto dashboard`
* http://localhost:8180

Doesn't show any data, but widgets don't appear if MQTT connection is refused